### PR TITLE
having a limit of 0 makes no sense

### DIFF
--- a/cuenca/validators.py
+++ b/cuenca/validators.py
@@ -20,7 +20,7 @@ class StrictPositiveInt(StrictInt, PositiveInt):
 
 
 class Limit(ConstrainedInt):
-    ge = 0
+    gt = 0
     le = MAX_PAGE_LIMIT
 
 

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'


### PR DESCRIPTION
limit being 0 means that `next_page_url` can't be defined. The only scenario where no items are returned are when `count=1`, but `limit` is not relevant in that case.