### PR TITLE
update dependencies

### DIFF
--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,10 @@ setup(
     package_data=dict(cuenca=['py.typed']),
     python_requires='>=3.6',
     install_requires=[
-        'clabe==1.2.1',
         'requests==2.24.0',
         'pydantic==1.5.1',
-        'cuenca-validations==0.2.3',
-        'dataclasses>=0.6;python_version<"3.7"',
+        'cuenca-validations==0.2.4',
+        'dataclasses>=0.7;python_version<"3.7"',
     ],
     setup_requires=['pytest-runner'],
     tests_require=test_requires,


### PR DESCRIPTION
- remove `clabe` as a direct dependency
- upgrade version of `cuenca-validations`
- upgrade minimum requirement for `dataclasses` for python 3.6