### PR TITLE
Aws iam

### DIFF
--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -134,8 +134,7 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
 
         # Combine elements to create create canonical request
         canonical_request = (
-            request.method
-            or ''
+            (request.method or '')
             + '\n'
             + canonical_uri
             + '\n'

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -128,7 +128,11 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
 
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').
-        body = str(request.body).encode('utf-8') if request.body else bytes()
+        body = request.body if request.body else bytes()
+        try:
+            body = body.encode('utf-8')
+        except (AttributeError, UnicodeDecodeError):
+            body = body
 
         payload_hash = hashlib.sha256(body).hexdigest()
 
@@ -146,7 +150,6 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
             + '\n'
             + payload_hash
         )
-
         # Match the algorithm to the hashing algorithm you use, either SHA-1 or
         # SHA-256 (recommended)
         algorithm = 'AWS4-HMAC-SHA256'
@@ -270,5 +273,4 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
                 if canonical_querystring:
                     canonical_querystring += "&"
                 canonical_querystring += u'='.join([key, val])
-
         return canonical_querystring

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -1,11 +1,13 @@
 from pathlib import PurePosixPath
 from urllib.parse import quote, unquote, urlparse
 
+from requests.models import Request
+
 AWS_ROUTES_DICT = dict(cards='/knox')
 DEFAULT_ROUTE = '/oaxaca'
 
 
-def get_canonical_path(r):
+def get_canonical_path(r: Request) -> str:
     """
     Create canonical URI--the part of the URI from domain to query
     string (use '/' if no path)
@@ -23,5 +25,4 @@ def get_canonical_path(r):
             canonical_path = DEFAULT_ROUTE
         finally:
             canonical_path += parsedurl.path
-    print(canonical_path)
     return quote(canonical_path, safe='/-_.~')

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -130,11 +130,10 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
         # requests, the payload is an empty string ('').
         body = request.body if request.body else bytes()
         try:
-            body = body.encode('utf-8')
-        except (AttributeError, UnicodeDecodeError):
-            body = body
-
-        payload_hash = hashlib.sha256(body).hexdigest()
+            body = body.encode('utf-8')  # type: ignore[union-attr]
+        except AttributeError:
+            ...
+        payload = hashlib.sha256(body).hexdigest()  # type: ignore[arg-type]
 
         # Combine elements to create create canonical request
         canonical_request = (
@@ -148,7 +147,7 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
             + '\n'
             + signed_headers
             + '\n'
-            + payload_hash
+            + payload
         )
         # Match the algorithm to the hashing algorithm you use, either SHA-1 or
         # SHA-256 (recommended)
@@ -207,7 +206,7 @@ class CuencaAWSRequestAuth(requests.auth.AuthBase):
         headers = {
             'Authorization': authorization_header,
             'x-amz-date': amzdate,
-            'x-amz-content-sha256': payload_hash,
+            'x-amz-content-sha256': payload,
         }
         return headers
 

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -1,0 +1,30 @@
+from pathlib import PurePosixPath
+from urllib.parse import quote, unquote, urlparse
+
+from aws_requests_auth.aws_auth import AWSRequestsAuth
+
+AWS_ROUTES_DICT = dict(cards='knox/')
+DEFAULT_ROUTE = 'oaxaca/'
+
+
+class CuencaAWSRequestsAuth(AWSRequestsAuth):
+    @classmethod
+    def get_canonical_path(cls, r):
+        """
+        Create canonical URI--the part of the URI from domain to query
+        string (use '/' if no path)
+        """
+        parsedurl = urlparse(r.url)
+
+        # safe chars adapted from boto's use of urllib.parse.quote
+        # https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/auth.py#L393
+        canonical_path = '/'
+        if parsedurl.path:
+            root = PurePosixPath(unquote(parsedurl.path)).parts[1]
+            try:
+                canonical_path = AWS_ROUTES_DICT[root]
+            except KeyError:
+                canonical_path = DEFAULT_ROUTE
+            finally:
+                canonical_path += parsedurl.path
+        return quote(canonical_path, safe='/-_.~')

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -1,29 +1,275 @@
+"""
+Based on https://github.com/DavidMuller/aws-requests-auth/blob/master/
+aws_requests_auth/aws_auth.py
+"""
+
+import datetime
+import hashlib
+import hmac
 from pathlib import PurePosixPath
+from typing import Dict
 from urllib.parse import quote, unquote, urlparse
 
-from requests.models import Request
+import requests
+from requests.models import PreparedRequest
 
-AWS_ROUTES_DICT = dict(cards='/knox')
-DEFAULT_ROUTE = '/oaxaca'
+ROUTE_CONFIGURATION = 'config/route_configuration.json'
 
 
-def get_canonical_path(r: Request) -> str:
+def sign(key: bytes, msg: str) -> bytes:
     """
-    Create canonical URI--the part of the URI from domain to query
-    string (use '/' if no path), based on the path it prepends the
-    correct route required for API Gateway depending on the root of the
-    path (ej. /cards/ID => /knox/cards/ID). It uses the DEFAULT_ROUTE if
-    nothing is found in the dict
+    Copied from https://docs.aws.amazon.com/general/latest/gr/
+    sigv4-signed-request-examples.html
     """
-    parsedurl = urlparse(r.url)
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
 
-    canonical_path = '/'
-    if parsedurl.path:
-        root = PurePosixPath(unquote(parsedurl.path)).parts[1]
-        try:
-            canonical_path = AWS_ROUTES_DICT[root]
-        except KeyError:
-            canonical_path = DEFAULT_ROUTE
-        finally:
-            canonical_path += parsedurl.path
-    return quote(canonical_path, safe='/-_.~')
+
+def get_signature_key(
+    key: str, date_stamp: str, region_name: str, service_name: str
+) -> bytes:
+    """
+    Copied from https://docs.aws.amazon.com/general/latest/gr/
+    sigv4-signed-request-examples.html
+    """
+    k_date = sign(('AWS4' + key).encode('utf-8'), date_stamp)
+    k_region = sign(k_date, region_name)
+    k_service = sign(k_region, service_name)
+    k_signing = sign(k_service, 'aws4_request')
+    return k_signing
+
+
+class CuencaAWSRequestAuth(requests.auth.AuthBase):
+    """
+    Auth class that allows us to connect to AWS services
+    via Amazon's signature version 4 signing process
+
+    Adapted from https://docs.aws.amazon.com/general/latest/gr/
+    sigv4-signed-request-examples.html
+    """
+
+    def __init__(
+        self,
+        aws_access_key: str,
+        aws_secret_access_key: str,
+        aws_host: str,
+        aws_region: str,
+        aws_service: str,
+    ):
+        """
+        Example usage for talking to an AWS Elasticsearch Service:
+
+        AWSRequestsAuth(aws_access_key='YOURKEY',
+                        aws_secret_access_key='YOURSECRET',
+                        aws_host='search-service-foobar.us-east-1.es.amazonaws.com',
+                        aws_region='us-east-1',
+                        aws_service='es',
+                        aws_token='...')
+
+        The aws_token is optional and is used only if you are using STS
+        temporary credentials.
+        """
+        self.aws_access_key = aws_access_key
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_host = aws_host
+        self.aws_region = aws_region
+        self.service = aws_service
+
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
+        """
+        Adds the authorization headers required by Amazon's signature
+        version 4 signing process to the request.
+
+        Adapted from https://docs.aws.amazon.com/general/latest/gr/
+        sigv4-signed-request-examples.html
+        """
+        aws_headers = self.get_aws_request_headers(request)
+        request.headers.update(aws_headers)
+        return request
+
+    def get_aws_request_headers(
+        self, request: PreparedRequest
+    ) -> Dict[str, str]:
+        """
+        Returns a dictionary containing the necessary headers for Amazon's
+        signature version 4 signing process. An example return value might
+        look like
+
+            {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=YOURKEY/20160618/
+                                 'us-east-1/es/aws4_request, '
+                                 'SignedHeaders=host;x-amz-date, '
+                                 'Signature=ca0a856286efce2a4bd96a978ca6c896605'
+                                 '7e53184776c0685169d08abd74739',
+                'x-amz-date': '20160618T220405Z',
+            }
+        """
+        # Create a date for headers and the credential string
+        time = datetime.datetime.utcnow()
+        amzdate = time.strftime('%Y%m%dT%H%M%SZ')
+        date_stamp = time.strftime('%Y%m%d')  # For credential_scope
+
+        canonical_uri = self.get_canonical_path(request)
+
+        canonical_querystring = self.get_canonical_querystring(request)
+
+        # Create the canonical headers and signed headers. Header names
+        # and value must be trimmed and lowercase, and sorted in ASCII order.
+        # Note that there is a trailing \n.
+        canonical_headers = (
+            'host:' + self.aws_host + '\n' + 'x-amz-date:' + amzdate + '\n'
+        )
+
+        # Create the list of signed headers. This lists the headers
+        # in the canonical_headers list, delimited with ";" and in alpha order.
+        # Note: The request can include any headers; canonical_headers and
+        # signed_headers lists those that you want to be included in the
+        # hash of the request. "Host" and "x-amz-date" are always required.
+        signed_headers = 'host;x-amz-date'
+
+        # Create payload hash (hash of the request body content). For GET
+        # requests, the payload is an empty string ('').
+        body = str(request.body).encode('utf-8') if request.body else bytes()
+
+        payload_hash = hashlib.sha256(body).hexdigest()
+
+        # Combine elements to create create canonical request
+        canonical_request = (
+            request.method
+            or ''
+            + '\n'
+            + canonical_uri
+            + '\n'
+            + canonical_querystring
+            + '\n'
+            + canonical_headers
+            + '\n'
+            + signed_headers
+            + '\n'
+            + payload_hash
+        )
+
+        # Match the algorithm to the hashing algorithm you use, either SHA-1 or
+        # SHA-256 (recommended)
+        algorithm = 'AWS4-HMAC-SHA256'
+        credential_scope = (
+            date_stamp
+            + '/'
+            + self.aws_region
+            + '/'
+            + self.service
+            + '/'
+            + 'aws4_request'
+        )
+        string_to_sign = (
+            algorithm
+            + '\n'
+            + amzdate
+            + '\n'
+            + credential_scope
+            + '\n'
+            + hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()
+        )
+
+        # Create the signing key using the function defined above.
+        signing_key = get_signature_key(
+            self.aws_secret_access_key,
+            date_stamp,
+            self.aws_region,
+            self.service,
+        )
+
+        # Sign the string_to_sign using the signing_key
+        string_to_sign_utf8 = string_to_sign.encode('utf-8')
+        signature = hmac.new(
+            signing_key, string_to_sign_utf8, hashlib.sha256
+        ).hexdigest()
+
+        # The signing information can be either in a query string value or in
+        # a header named Authorization. This code shows how to use a header.
+        # Create authorization header and add to request headers
+        authorization_header = (
+            algorithm
+            + ' '
+            + 'Credential='
+            + self.aws_access_key
+            + '/'
+            + credential_scope
+            + ', '
+            + 'SignedHeaders='
+            + signed_headers
+            + ', '
+            + 'Signature='
+            + signature
+        )
+
+        headers = {
+            'Authorization': authorization_header,
+            'x-amz-date': amzdate,
+            'x-amz-content-sha256': payload_hash,
+        }
+        return headers
+
+    def get_canonical_path(self, request: PreparedRequest) -> str:
+        """
+        Create canonical URI--the part of the URI from domain to query
+        string (use '/' if no path), based on the path it prepends the
+        correct route required for API Gateway depending on the root of the
+        path (ej. /cards/ID => /knox/cards/ID). It uses the DEFAULT_ROUTE if
+        nothing is found in the dict
+        """
+        parsed_url = urlparse(request.url)
+        self.route_configuration = requests.get(
+            f'https://{self.aws_host}/{ROUTE_CONFIGURATION}'
+        ).json()
+
+        canonical_path = '/'
+        if parsed_url.path:
+            path = str(parsed_url.path)
+            root = PurePosixPath(unquote(path)).parts[1]
+            try:
+                canonical_path = self.route_configuration['routes'][root]
+            except KeyError:
+                canonical_path = self.route_configuration['default_route']
+            finally:
+                canonical_path += path
+        return quote(canonical_path, safe='/-_.~')
+
+    def get_canonical_querystring(self, request: PreparedRequest) -> str:
+        """
+        Create the canonical query string. According to AWS, by the
+        end of this function our query string values must
+        be URL-encoded (space=%20) and the parameters must be sorted
+        by name.
+
+        This method assumes that the query params in `r` are *already*
+        url encoded.  If they are not url encoded by the time they make
+        it to this function, AWS may complain that the signature for your
+        request is incorrect.
+
+        It appears elasticsearc-py url encodes query paramaters on its own:
+            https://github.com/elastic/elasticsearch-py/blob/5dfd6985e5d32ea353d2b37d01c2521b2089ac2b/elasticsearch/connection/http_requests.py#L64
+
+        If you are using a different client than elasticsearch-py, it
+        will be your responsibility to urleconde your query params before
+        this method is called.
+        """
+        canonical_querystring = ''
+
+        parsed_url = urlparse(request.url)
+        query = str(parsed_url.query)
+        querystring_sorted = '&'.join(sorted(query.split('&')))
+
+        for query_param in querystring_sorted.split('&'):
+            key_val_split = query_param.split('=', 1)
+            key = key_val_split[0]
+            if len(key_val_split) > 1:
+                val = key_val_split[1]
+            else:
+                val = ''
+
+            if key:
+                if canonical_querystring:
+                    canonical_querystring += "&"
+                canonical_querystring += u'='.join([key, val])
+
+        return canonical_querystring

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -1,30 +1,27 @@
 from pathlib import PurePosixPath
 from urllib.parse import quote, unquote, urlparse
 
-from aws_requests_auth.aws_auth import AWSRequestsAuth
-
-AWS_ROUTES_DICT = dict(cards='knox/')
-DEFAULT_ROUTE = 'oaxaca/'
+AWS_ROUTES_DICT = dict(cards='/knox')
+DEFAULT_ROUTE = '/oaxaca'
 
 
-class CuencaAWSRequestsAuth(AWSRequestsAuth):
-    @classmethod
-    def get_canonical_path(cls, r):
-        """
-        Create canonical URI--the part of the URI from domain to query
-        string (use '/' if no path)
-        """
-        parsedurl = urlparse(r.url)
+def get_canonical_path(r):
+    """
+    Create canonical URI--the part of the URI from domain to query
+    string (use '/' if no path)
+    """
+    parsedurl = urlparse(r.url)
 
-        # safe chars adapted from boto's use of urllib.parse.quote
-        # https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/auth.py#L393
-        canonical_path = '/'
-        if parsedurl.path:
-            root = PurePosixPath(unquote(parsedurl.path)).parts[1]
-            try:
-                canonical_path = AWS_ROUTES_DICT[root]
-            except KeyError:
-                canonical_path = DEFAULT_ROUTE
-            finally:
-                canonical_path += parsedurl.path
-        return quote(canonical_path, safe='/-_.~')
+    # safe chars adapted from boto's use of urllib.parse.quote
+    # https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/auth.py#L393
+    canonical_path = '/'
+    if parsedurl.path:
+        root = PurePosixPath(unquote(parsedurl.path)).parts[1]
+        try:
+            canonical_path = AWS_ROUTES_DICT[root]
+        except KeyError:
+            canonical_path = DEFAULT_ROUTE
+        finally:
+            canonical_path += parsedurl.path
+    print(canonical_path)
+    return quote(canonical_path, safe='/-_.~')

--- a/cuenca/http/aws_auth.py
+++ b/cuenca/http/aws_auth.py
@@ -10,12 +10,13 @@ DEFAULT_ROUTE = '/oaxaca'
 def get_canonical_path(r: Request) -> str:
     """
     Create canonical URI--the part of the URI from domain to query
-    string (use '/' if no path)
+    string (use '/' if no path), based on the path it prepends the
+    correct route required for API Gateway depending on the root of the
+    path (ej. /cards/ID => /knox/cards/ID). It uses the DEFAULT_ROUTE if
+    nothing is found in the dict
     """
     parsedurl = urlparse(r.url)
 
-    # safe chars adapted from boto's use of urllib.parse.quote
-    # https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/auth.py#L393
     canonical_path = '/'
     if parsedurl.path:
         root = PurePosixPath(unquote(parsedurl.path)).parts[1]

--- a/cuenca/http/client.py
+++ b/cuenca/http/client.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
-from aws_requests_auth.aws_auth import AWSRequestsAuth
 from cuenca_validations.typing import (
     ClientRequestParams,
     DictStrAny,
@@ -13,20 +12,19 @@ from requests import Response
 
 from ..exc import CuencaResponseException
 from ..version import API_VERSION, CLIENT_VERSION
-from .aws_auth import get_canonical_path
+from .aws_auth import CuencaAWSRequestAuth
 
 API_HOST = 'api.cuenca.com'
 SANDBOX_HOST = 'sandbox.cuenca.com'
 AWS_DEFAULT_REGION = 'us-east-1'
 AWS_SERVICE = 'execute-api'
-AWSRequestsAuth.get_canonical_path = get_canonical_path
 
 
 class Session:
 
     host: str = API_HOST
     basic_auth: Tuple[str, str]
-    iam_auth: Optional[AWSRequestsAuth] = None
+    iam_auth: Optional[CuencaAWSRequestAuth] = None
     session: requests.Session
 
     def __init__(self):
@@ -48,7 +46,7 @@ class Session:
         aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY', '')
         aws_region = os.getenv('AWS_DEFAULT_REGION', AWS_DEFAULT_REGION)
         if aws_access_key and aws_secret_access_key:
-            self.iam_auth = AWSRequestsAuth(
+            self.iam_auth = CuencaAWSRequestAuth(
                 aws_access_key=aws_access_key,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_host=self.host,
@@ -57,7 +55,7 @@ class Session:
             )
 
     @property
-    def auth(self) -> Union[AWSRequestsAuth, Tuple[str, str]]:
+    def auth(self) -> Union[CuencaAWSRequestAuth, Tuple[str, str], None]:
         # preference to basic auth
         return self.basic_auth if all(self.basic_auth) else self.iam_auth
 
@@ -87,7 +85,7 @@ class Session:
         )
 
         # IAM auth
-        if self.iam_auth is not None:
+        if self.iam_auth:
             self.iam_auth.aws_access_key = (
                 aws_access_key or self.iam_auth.aws_access_key
             )
@@ -95,8 +93,9 @@ class Session:
                 aws_secret_access_key or self.iam_auth.aws_secret_access_key
             )
             self.iam_auth.aws_region = aws_region or self.iam_auth.aws_region
+            self.aws_host = self.host
         elif aws_access_key and aws_secret_access_key:
-            self.iam_auth = AWSRequestsAuth(
+            self.iam_auth = CuencaAWSRequestAuth(
                 aws_access_key=aws_access_key,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_host=self.host,

--- a/cuenca/http/client.py
+++ b/cuenca/http/client.py
@@ -16,7 +16,7 @@ from ..version import API_VERSION, CLIENT_VERSION
 from .aws_auth import get_canonical_path
 
 API_HOST = 'api.cuenca.com'
-SANDBOX_HOST = 'stage.cuenca.com'
+SANDBOX_HOST = 'sandbox.cuenca.com'
 AWS_DEFAULT_REGION = 'us-east-1'
 AWS_SERVICE = 'execute-api'
 AWSRequestsAuth.get_canonical_path = get_canonical_path

--- a/cuenca/http/client.py
+++ b/cuenca/http/client.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
-from aws_requests_auth.aws_auth import AWSRequestsAuth
 from cuenca_validations.typing import (
     ClientRequestParams,
     DictStrAny,
@@ -13,6 +12,7 @@ from requests import Response
 
 from ..exc import CuencaResponseException
 from ..version import API_VERSION, CLIENT_VERSION
+from .aws_auth import CuencaAWSRequestsAuth
 
 API_HOST = 'api.cuenca.com'
 SANDBOX_HOST = 'sandbox.cuenca.com'
@@ -24,7 +24,7 @@ class Session:
 
     host: str = API_HOST
     basic_auth: Tuple[str, str]
-    iam_auth: Optional[AWSRequestsAuth] = None
+    iam_auth: Optional[CuencaAWSRequestsAuth] = None
     session: requests.Session
 
     def __init__(self):
@@ -46,7 +46,7 @@ class Session:
         aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY', '')
         aws_region = os.getenv('AWS_DEFAULT_REGION', AWS_DEFAULT_REGION)
         if aws_access_key and aws_secret_access_key:
-            self.iam_auth = AWSRequestsAuth(
+            self.iam_auth = CuencaAWSRequestsAuth(
                 aws_access_key=aws_access_key,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_host=self.host,
@@ -55,7 +55,7 @@ class Session:
             )
 
     @property
-    def auth(self) -> Union[AWSRequestsAuth, Tuple[str, str]]:
+    def auth(self) -> Union[Optional[CuencaAWSRequestsAuth], Tuple[str, str]]:
         # preference to basic auth
         return self.basic_auth if all(self.basic_auth) else self.iam_auth
 
@@ -94,7 +94,7 @@ class Session:
             )
             self.iam_auth.aws_region = aws_region or self.iam_auth.aws_region
         elif aws_access_key and aws_secret_access_key:
-            self.iam_auth = AWSRequestsAuth(
+            self.iam_auth = CuencaAWSRequestsAuth(
                 aws_access_key=aws_access_key,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_host=self.host,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ black==20.8b1
 isort==5.6.*
 flake8==3.8.*
 mypy==0.782
+freezegun==1.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.24.0
 cuenca-validations==0.6.2
 dataclasses>=0.7;python_version<"3.7"
-aws-requests-auth==0.4.3

--- a/tests/http/test_aws_auth.py
+++ b/tests/http/test_aws_auth.py
@@ -1,0 +1,27 @@
+import pytest
+from requests.models import Request
+
+from cuenca.http.aws_auth import get_canonical_path
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            Request(url='https://stage.cuenca.com/transfers'),
+            '/oaxaca/transfers',
+        ),
+        (
+            Request(url='https://stage.cuenca.com/transfers/TESTING'),
+            '/oaxaca/transfers/TESTING',
+        ),
+        (Request(url='https://stage.cuenca.com/cards'), '/knox/cards'),
+        (
+            Request(url='https://stage.cuenca.com/cards/TESTING'),
+            '/knox/cards/TESTING',
+        ),
+        (Request(url='https://stage.cuenca.com'), '/'),
+    ],
+)
+def test_aws_auth(test_input, expected):
+    assert get_canonical_path(test_input) == expected

--- a/tests/http/test_aws_auth.py
+++ b/tests/http/test_aws_auth.py
@@ -68,8 +68,8 @@ def test_auth(auth):
     assert {
         'Authorization': 'AWS4-HMAC-SHA256 Credential=testing_key/20201125/'
         'us-east-1/execute-api/aws4_request, SignedHeaders'
-        '=host;x-amz-date, Signature=7df1a4b3f3effedc96a9e'
-        'a9da39392a7ac42259688aa93ac60a4817a5431f813',
+        '=host;x-amz-date, Signature=61bbed824d3bb736d4622'
+        '47601f2d9f15ebe36994f1782172be23044250322bd',
         'x-amz-date': '20201125T030000Z',
         'x-amz-content-sha256': hashlib.sha256(b'').hexdigest(),
     } == mock_request.headers


### PR DESCRIPTION
Utiliza una forma diferente de calcular el Canonical String en la firma de AWS para que pueda ser consistente con lo que espera API Gateway. Más detalles en: https://github.com/cuenca-mx/knox/issues/17.
En especial es el `path` el que debe ser modificado para que coincida con las rutas que existen en el Custom Domain Name dentro de API Gateway