### PR TITLE
s/ct/obj for retrieve_uris

### DIFF
--- a/cuenca/resources/resources.py
+++ b/cuenca/resources/resources.py
@@ -18,4 +18,6 @@ def retrieve_uri(uri: str) -> Retrievable:
 
 def retrieve_uris(uris: List[str]) -> List[Retrievable]:
     with ThreadPoolExecutor(max_workers=len(uris)) as executor:
-        return [obj for obj in executor.map(retrieve_uri, [uri for uri in uris])]
+        return [
+            obj for obj in executor.map(retrieve_uri, [uri for uri in uris])
+        ]

--- a/cuenca/resources/resources.py
+++ b/cuenca/resources/resources.py
@@ -18,4 +18,4 @@ def retrieve_uri(uri: str) -> Retrievable:
 
 def retrieve_uris(uris: List[str]) -> List[Retrievable]:
     with ThreadPoolExecutor(max_workers=len(uris)) as executor:
-        return [ct for ct in executor.map(retrieve_uri, [uri for uri in uris])]
+        return [obj for obj in executor.map(retrieve_uri, [uri for uri in uris])]

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'


### PR DESCRIPTION
use `obj` over `ct` for a generic variable name in `retrieve_uris`