### PR TITLE
Http

### DIFF
--- a/cuenca/http/client.py
+++ b/cuenca/http/client.py
@@ -22,6 +22,7 @@ AWS_SERVICE = 'execute-api'
 
 class Session:
 
+    scheme: str = 'https'
     host: str = API_HOST
     basic_auth: Tuple[str, str]
     jwt_token: Optional[Jwt] = None
@@ -51,6 +52,7 @@ class Session:
         api_secret: Optional[str] = None,
         use_jwt: Optional[bool] = False,
         sandbox: Optional[bool] = None,
+        use_http: Optional[bool] = False,
     ):
         """
         This allows us to instantiate the http client when importing the
@@ -70,6 +72,9 @@ class Session:
 
         if use_jwt:
             self.jwt_token = Jwt.create(self)
+
+        if use_http:
+            self.scheme = 'http'
 
     def get(
         self,
@@ -102,7 +107,7 @@ class Session:
 
         resp = self.session.request(
             method=method,
-            url='https://' + self.host + urljoin('/', endpoint),
+            url=f'{self.scheme}://{self.host}{urljoin("/", endpoint)}',
             auth=self.auth,
             json=data,
             params=params,

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -73,3 +73,15 @@ def test_overrides_session(mock_request):
     mock_request.assert_called_once()
     _, kwargs = mock_request.call_args_list[0]
     assert kwargs['auth'] == session.auth
+
+
+@pytest.mark.parametrize('scheme', [('https'), ('http')])
+@patch('cuenca.http.client.requests.Session.request')
+def test_use_http(mock_request, scheme):
+    session = Session()
+    session.configure(use_http=scheme == 'http')
+
+    session.get('health_check')
+    mock_request.assert_called_once()
+    _, kwargs = mock_request.call_args_list[0]
+    assert f'{scheme}://' in kwargs['url']


### PR DESCRIPTION
This is a proposal for #106. I was also considering to replace `API_HOST` with `API_BASE_URL` to include the protocol as `https://api.cuenca.com`, so that we can override it for internal applications but I feel this way is clearer.