### PR TITLE
Related_card_transactions return an empty list

### DIFF
--- a/cuenca/resources/card_transactions.py
+++ b/cuenca/resources/card_transactions.py
@@ -28,7 +28,7 @@ class CardTransaction(Transaction):
     @property  # type: ignore
     def related_card_transactions(self) -> Optional[List['CardTransaction']]:
         if not self.related_card_transaction_uris:
-            return list()
+            return []
         return cast(
             List['CardTransaction'],
             retrieve_uris(self.related_card_transaction_uris),

--- a/cuenca/resources/card_transactions.py
+++ b/cuenca/resources/card_transactions.py
@@ -28,7 +28,7 @@ class CardTransaction(Transaction):
     @property  # type: ignore
     def related_card_transactions(self) -> Optional[List['CardTransaction']]:
         if not self.related_card_transaction_uris:
-            return None
+            return list()
         return cast(
             List['CardTransaction'],
             retrieve_uris(self.related_card_transaction_uris),


### PR DESCRIPTION
This PR changes the return value of `CardTransaction.related_card_transactions`:  if `related_card_transaction_uris` is an empty list `related_card_transactions` will also return an empty list.