### PR TITLE
freeze_time for the cassette

### DIFF
--- a/tests/resources/test_user_credentials.py
+++ b/tests/resources/test_user_credentials.py
@@ -1,4 +1,5 @@
 import pytest
+from freezegun import freeze_time
 
 from cuenca import UserCredential, UserLogin
 from cuenca.http import Session
@@ -12,6 +13,7 @@ def test_update_password():
 
 
 @pytest.mark.vcr
+@freeze_time('2020-03-19')
 def test_block_user():
     session = Session()
     session.configure(


### PR DESCRIPTION
Since the cassette for this test was created days ago. It detects the token as invalid and try to create a new one causing an `CannotOverwriteExistingCassetteException`. I'm using `freeze_time` so the test will always run under the same conditions.