### PR TITLE
automerge dependabot (#220)

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,13 +1,15 @@
-name: auto-merge
+name: 'Merge Dependencies'
 
-on:
-  pull_request:
+on: [pull_request_target]
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - name: 'Checkout repository'
+        uses: actions/checkout@v2.3.4
+      - name: 'Automerge dependency updates from Dependabot'
+        uses: ahmadnassri/action-dependabot-auto-merge@v2.4.0
         with:
           github-token: ${{ secrets.DEPENDABOT_AUTOMERGE }}

--- a/cuenca/resources/__init__.py
+++ b/cuenca/resources/__init__.py
@@ -19,7 +19,6 @@ __all__ = [
     'WalletTransaction',
     'WhatsappTransfer',
 ]
-
 from .accounts import Account
 from .api_keys import ApiKey
 from .arpc import Arpc

--- a/cuenca/resources/__init__.py
+++ b/cuenca/resources/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     'WalletTransaction',
     'WhatsappTransfer',
 ]
+
 from .accounts import Account
 from .api_keys import ApiKey
 from .arpc import Arpc


### PR DESCRIPTION
According to this issue, auto-merge dependabot stop workings because github restric access token from dependabot

https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60

We find this solution and upgrade library

https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-806170152[](https://github.com/alexviquez)


* auto-test

* fix auto-merge

* auto-test