### PR TITLE
Curp Document Uri

### DIFF
--- a/cuenca/resources/users.py
+++ b/cuenca/resources/users.py
@@ -16,7 +16,7 @@ from cuenca_validations.types import (
 )
 from cuenca_validations.types.enums import Country, Gender, State
 from cuenca_validations.types.identities import CurpField
-from pydantic import EmailStr
+from pydantic import EmailStr, HttpUrl
 
 from ..http import Session, session as global_session
 from .balance_entries import BalanceEntry
@@ -154,6 +154,7 @@ class User(Creatable, Retrievable, Updateable, Queryable):
         status: Optional[UserStatus] = None,
         email_verification_id: Optional[str] = None,
         phone_verification_id: Optional[str] = None,
+        curp_document: Optional[HttpUrl] = None,
         *,
         session: Session = global_session,
     ):
@@ -170,6 +171,7 @@ class User(Creatable, Retrievable, Updateable, Queryable):
             verification_id=verification_id,
             email_verification_id=email_verification_id,
             phone_verification_id=phone_verification_id,
+            curp_document=curp_document,
             status=status,
         )
         return cast(

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.15.5'
+__version__ = '0.15.6'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.27.1
-cuenca-validations==0.11.15.dev4
+cuenca-validations==0.11.15
 dataclasses>=0.7;python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.27.1
-cuenca-validations==0.11.12
+cuenca-validations==0.11.15.dev4
 dataclasses>=0.7;python_version<"3.7"


### PR DESCRIPTION
This PR allows users to update `curp_document_uri` and be queried by `has_curp_document`

### To update `curp_document_uri` field:
```python
cuenca.User.update('US01', curp_document='https://sandbox.cuenca.com/files/EF987')
```

### All users with `curp_document_uri`
```python
cuenca.User.all(has_curp_document=True)
```

### All users without `curp_document_uri`
```python
cuenca.User.all(has_curp_document=False)
```