### PR TITLE
Dependency/update cuenca validations

### DIFF
--- a/cuenca/resources/endpoints.py
+++ b/cuenca/resources/endpoints.py
@@ -1,11 +1,12 @@
 from typing import ClassVar, Optional
 
 from cuenca_validations.types.enums import WebhookEvent
+from cuenca_validations.types.general import HttpUrlString
 from cuenca_validations.types.requests import (
     EndpointRequest,
     EndpointUpdateRequest,
 )
-from pydantic import ConfigDict, Field, HttpUrl
+from pydantic import ConfigDict, Field
 
 from ..http import Session, session as global_session
 from .base import Creatable, Deactivable, Queryable, Retrievable, Updateable
@@ -14,7 +15,7 @@ from .base import Creatable, Deactivable, Queryable, Retrievable, Updateable
 class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     _resource: ClassVar = 'endpoints'
 
-    url: HttpUrl = Field(description='HTTPS url to send webhooks')
+    url: HttpUrlString = Field(description='HTTPS url to send webhooks')
     secret: str = Field(
         description='token to verify the webhook is sent by Cuenca '
         'using HMAC algorithm',
@@ -51,7 +52,7 @@ class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     @classmethod
     def create(
         cls,
-        url: HttpUrl,
+        url: HttpUrlString,
         events: Optional[list[WebhookEvent]] = None,
         *,
         session: Session = global_session,
@@ -72,7 +73,7 @@ class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     def update(
         cls,
         endpoint_id: str,
-        url: Optional[HttpUrl] = None,
+        url: Optional[HttpUrlString] = None,
         events: Optional[list[WebhookEvent]] = None,
         is_enable: Optional[bool] = None,
         *,

--- a/cuenca/resources/endpoints.py
+++ b/cuenca/resources/endpoints.py
@@ -1,7 +1,7 @@
 from typing import ClassVar, Optional
 
 from cuenca_validations.types.enums import WebhookEvent
-from cuenca_validations.types.general import HttpUrlString
+from cuenca_validations.types.general import SerializableHttpUrl
 from cuenca_validations.types.requests import (
     EndpointRequest,
     EndpointUpdateRequest,
@@ -15,7 +15,7 @@ from .base import Creatable, Deactivable, Queryable, Retrievable, Updateable
 class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     _resource: ClassVar = 'endpoints'
 
-    url: HttpUrlString = Field(description='HTTPS url to send webhooks')
+    url: SerializableHttpUrl = Field(description='HTTPS url to send webhooks')
     secret: str = Field(
         description='token to verify the webhook is sent by Cuenca '
         'using HMAC algorithm',
@@ -52,7 +52,7 @@ class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     @classmethod
     def create(
         cls,
-        url: HttpUrlString,
+        url: SerializableHttpUrl,
         events: Optional[list[WebhookEvent]] = None,
         *,
         session: Session = global_session,
@@ -73,7 +73,7 @@ class Endpoint(Creatable, Deactivable, Retrievable, Queryable, Updateable):
     def update(
         cls,
         endpoint_id: str,
-        url: Optional[HttpUrlString] = None,
+        url: Optional[SerializableHttpUrl] = None,
         events: Optional[list[WebhookEvent]] = None,
         is_enable: Optional[bool] = None,
         *,

--- a/cuenca/resources/files.py
+++ b/cuenca/resources/files.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import ClassVar, Optional
 
 from cuenca_validations.types import FileQuery, FileUploadRequest, KYCFileType
-from cuenca_validations.types.general import HttpUrlString
+from cuenca_validations.types.general import SerializableHttpUrl
 
 from ..http import Session, session as global_session
 from .base import Downloadable, Queryable, Uploadable
@@ -14,7 +14,7 @@ class File(Downloadable, Queryable, Uploadable):
 
     extension: str
     type: KYCFileType
-    url: HttpUrlString
+    url: SerializableHttpUrl
     user_id: str
 
     @classmethod

--- a/cuenca/resources/files.py
+++ b/cuenca/resources/files.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import ClassVar, Optional
 
 from cuenca_validations.types import FileQuery, FileUploadRequest, KYCFileType
-from pydantic import HttpUrl
+from cuenca_validations.types.general import HttpUrlString
 
 from ..http import Session, session as global_session
 from .base import Downloadable, Queryable, Uploadable
@@ -14,7 +14,7 @@ class File(Downloadable, Queryable, Uploadable):
 
     extension: str
     type: KYCFileType
-    url: HttpUrl
+    url: HttpUrlString
     user_id: str
 
     @classmethod

--- a/cuenca/resources/sessions.py
+++ b/cuenca/resources/sessions.py
@@ -2,7 +2,7 @@ import datetime as dt
 from typing import ClassVar, Optional
 
 from cuenca_validations.types import SessionRequest, SessionType
-from cuenca_validations.types.general import AnyUrlString
+from cuenca_validations.types.general import SerializableAnyUrl
 from pydantic import ConfigDict
 
 from .. import http
@@ -17,8 +17,8 @@ class Session(Creatable, Retrievable, Queryable):
     user_id: str
     platform_id: str
     expires_at: dt.datetime
-    success_url: Optional[AnyUrlString] = None
-    failure_url: Optional[AnyUrlString] = None
+    success_url: Optional[SerializableAnyUrl] = None
+    failure_url: Optional[SerializableAnyUrl] = None
     type: Optional[SessionType] = None
 
     model_config = ConfigDict(

--- a/cuenca/resources/sessions.py
+++ b/cuenca/resources/sessions.py
@@ -2,7 +2,8 @@ import datetime as dt
 from typing import ClassVar, Optional
 
 from cuenca_validations.types import SessionRequest, SessionType
-from pydantic import AnyUrl, ConfigDict
+from cuenca_validations.types.general import AnyUrlString
+from pydantic import ConfigDict
 
 from .. import http
 from .base import Creatable, Queryable, Retrievable
@@ -16,8 +17,8 @@ class Session(Creatable, Retrievable, Queryable):
     user_id: str
     platform_id: str
     expires_at: dt.datetime
-    success_url: Optional[AnyUrl] = None
-    failure_url: Optional[AnyUrl] = None
+    success_url: Optional[AnyUrlString] = None
+    failure_url: Optional[AnyUrlString] = None
     type: Optional[SessionType] = None
 
     model_config = ConfigDict(

--- a/cuenca/resources/user_credentials.py
+++ b/cuenca/resources/user_credentials.py
@@ -5,7 +5,6 @@ from cuenca_validations.types.requests import (
     UserCredentialRequest,
     UserCredentialUpdateRequest,
 )
-from pydantic import SecretStr
 
 from ..http import Session, session as global_session
 from .base import Creatable, Updateable
@@ -27,8 +26,7 @@ class UserCredential(Creatable, Updateable):
     ) -> 'UserCredential':
         req = UserCredentialRequest(password=password, user_id=user_id)
         data = req.model_dump()
-        if isinstance(data['password'], SecretStr):
-            data['password'] = data['password'].get_secret_value()
+        data['password'] = data['password'].get_secret_value()
         return cls._create(**data, session=session)
 
     @classmethod
@@ -45,6 +43,6 @@ class UserCredential(Creatable, Updateable):
             password=password,
         )
         data = req.model_dump()
-        if password and isinstance(data['password'], SecretStr):
+        if password:
             data['password'] = data['password'].get_secret_value()
         return cls._update(id=user_id, **data, session=session)

--- a/cuenca/resources/users.py
+++ b/cuenca/resources/users.py
@@ -15,7 +15,7 @@ from cuenca_validations.types import (
     UserUpdateRequest,
 )
 from cuenca_validations.types.enums import Country, Gender, State
-from cuenca_validations.types.general import HttpUrlString
+from cuenca_validations.types.general import SerializableHttpUrl
 from cuenca_validations.types.identities import Curp
 from pydantic import ConfigDict, EmailStr, Field
 
@@ -148,7 +148,7 @@ class User(Creatable, Retrievable, Updateable, Queryable):
         status: Optional[UserStatus] = None,
         email_verification_id: Optional[str] = None,
         phone_verification_id: Optional[str] = None,
-        curp_document: Optional[HttpUrlString] = None,
+        curp_document: Optional[SerializableHttpUrl] = None,
         *,
         session: Session = global_session,
     ) -> 'User':

--- a/cuenca/resources/users.py
+++ b/cuenca/resources/users.py
@@ -15,8 +15,9 @@ from cuenca_validations.types import (
     UserUpdateRequest,
 )
 from cuenca_validations.types.enums import Country, Gender, State
+from cuenca_validations.types.general import HttpUrlString
 from cuenca_validations.types.identities import Curp
-from pydantic import ConfigDict, EmailStr, Field, HttpUrl
+from pydantic import ConfigDict, EmailStr, Field
 
 from ..http import Session, session as global_session
 from .balance_entries import BalanceEntry
@@ -147,7 +148,7 @@ class User(Creatable, Retrievable, Updateable, Queryable):
         status: Optional[UserStatus] = None,
         email_verification_id: Optional[str] = None,
         phone_verification_id: Optional[str] = None,
-        curp_document: Optional[HttpUrl] = None,
+        curp_document: Optional[HttpUrlString] = None,
         *,
         session: Session = global_session,
     ) -> 'User':

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.32.3
-cuenca-validations==2.0.0
+cuenca-validations==2.0.4
 pydantic-extra-types==2.10.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         'requests>=2.32.0',
-        'cuenca-validations>=2.0.0',
+        'cuenca-validations>=2.0.4',
         'pydantic-extra-types>=2.10.0',
     ],
     classifiers=[

--- a/tests/resources/cassettes/test_update_password.yaml
+++ b/tests/resources/cassettes/test_update_password.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"password": "222222"}'
+    body: '{"password": "22222222"}'
     headers:
       Accept:
       - '*/*'
@@ -54,7 +54,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"password": "222222"}'
+    body: '{"password": "22222222"}'
     headers:
       Accept:
       - '*/*'
@@ -108,7 +108,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"is_active": null, "password": "111111"}'
+    body: '{"is_active": null, "password": "11111111"}'
     headers:
       Accept:
       - '*/*'

--- a/tests/resources/test_user_credentials.py
+++ b/tests/resources/test_user_credentials.py
@@ -7,9 +7,9 @@ from cuenca.http import Session
 
 @pytest.mark.vcr
 def test_update_password():
-    UserCredential.create('222222')
-    UserLogin.create('222222')
-    UserCredential.update(password='111111')
+    UserCredential.create('22222222')
+    UserLogin.create('22222222')
+    UserCredential.update(password='11111111')
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
## Description

This PR updates the project to use the latest version of `cuenca-validations`

### Changes
- Replacing `HttpUrl` and `AnyUrl` with `SerializableHttpUrl` and `SerializableAnyUrl`, respectively, to avoid serialization issues.
- Adapting to the updated `password` field in `cuenca-validations`, which is now of type `SecretStr` with a minimum of 8 characters.
- Adding logic in `user_credentials.py` to handle serialization of `password` when it is a `SecretStr` by using its `get_secret_value()` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v2.0.1

- **New Features**
	- Enhanced URL handling with improved serialization capabilities

- **Bug Fixes**
	- Updated password handling for improved security

- **Chores**
	- Updated `cuenca-validations` package to version 2.0.4
	- Bumped library version to 2.0.1

- **Internal Improvements**
	- Refined type management for URLs across multiple resources
	- Improved credential management methods
<!-- end of auto-generated comment: release notes by coderabbit.ai -->