### PR TITLE
Agregar resource id para sessions create

### DIFF
--- a/cuenca/resources/sessions.py
+++ b/cuenca/resources/sessions.py
@@ -33,7 +33,7 @@ class Session(Creatable, Retrievable, Queryable):
                 'success_url': 'http://example_success.com',
                 'failure_url': 'http://example_failure.com',
                 'type': 'session.registration',
-                'resource_id': 'some_resource_id'
+                'resource_id': 'some_resource_id',
             }
         }
     )
@@ -54,6 +54,6 @@ class Session(Creatable, Retrievable, Queryable):
             type=type,
             success_url=success_url,
             failure_url=failure_url,
-            resource_id=resource_id
+            resource_id=resource_id,
         )
         return cls._create(session=session, **req.model_dump())

--- a/cuenca/resources/sessions.py
+++ b/cuenca/resources/sessions.py
@@ -20,6 +20,7 @@ class Session(Creatable, Retrievable, Queryable):
     success_url: Optional[SerializableAnyUrl] = None
     failure_url: Optional[SerializableAnyUrl] = None
     type: Optional[SessionType] = None
+    resource_id: Optional[str] = None
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -32,6 +33,7 @@ class Session(Creatable, Retrievable, Queryable):
                 'success_url': 'http://example_success.com',
                 'failure_url': 'http://example_failure.com',
                 'type': 'session.registration',
+                'resource_id': 'some_resource_id'
             }
         }
     )
@@ -43,6 +45,7 @@ class Session(Creatable, Retrievable, Queryable):
         type: SessionType,
         success_url: Optional[str] = None,
         failure_url: Optional[str] = None,
+        resource_id: Optional[str] = None,
         *,
         session: http.Session = http.session,
     ) -> 'Session':
@@ -51,5 +54,6 @@ class Session(Creatable, Retrievable, Queryable):
             type=type,
             success_url=success_url,
             failure_url=failure_url,
+            resource_id=resource_id
         )
         return cls._create(session=session, **req.model_dump())

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '2.1.11.dev1'
+__version__ = '2.1.11'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/cuenca/version.py
+++ b/cuenca/version.py
@@ -1,3 +1,3 @@
-__version__ = '2.1.10'
+__version__ = '2.1.11.dev1'
 CLIENT_VERSION = __version__
 API_VERSION = '2020-03-19'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.32.3
-cuenca-validations==2.1.16
+cuenca-validations==2.1.17.dev3
 pydantic-extra-types==2.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.32.3
-cuenca-validations==2.1.17.dev3
+cuenca-validations==2.1.17.dev4
 pydantic-extra-types==2.10.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from io import BytesIO
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from cuenca_validations.types import Country, Gender, SessionType, State
@@ -82,7 +82,7 @@ def file() -> BytesIO:
 
 
 @pytest.fixture
-def session_with_resource_id() -> Generator[Session]:
+def session_with_resource_id() -> Generator[Session, Any, Any]:
     session = Session.create(
         'USPR4JxMuwSG60u2h4gBpB6Q',
         SessionType.onboarding_verification,
@@ -94,7 +94,7 @@ def session_with_resource_id() -> Generator[Session]:
 @pytest.fixture
 def client_authed_with_session(
     session_with_resource_id: Session,
-) -> Generator[ClientSession]:
+) -> Generator[ClientSession, Any, Any]:
     client = ClientSession()
     client.configure(session_token=session_with_resource_id.id, sandbox=True)
     client.basic_auth = ('', '')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import datetime as dt
 from io import BytesIO
+from typing import Generator
 
 import pytest
-from cuenca_validations.types import Country, Gender, State
+from cuenca_validations.types import Country, Gender, SessionType, State
 from cuenca_validations.types.enums import Profession
 
 import cuenca
+from cuenca.http import Session as ClientSession
+from cuenca.resources.sessions import Session
 
 cuenca.configure(sandbox=True)
 
@@ -76,3 +79,23 @@ def user_lists_request() -> dict:
 def file() -> BytesIO:
     with open('tests/data/test_file.jpeg', 'rb') as image_file:
         return BytesIO(image_file.read())
+
+
+@pytest.fixture
+def session_with_resource_id() -> Generator[Session]:
+    session = Session.create(
+        'USPR4JxMuwSG60u2h4gBpB6Q',
+        SessionType.onboarding_verification,
+        resource_id='68b887f60c33abad1ea841d3',
+    )
+    yield session
+
+
+@pytest.fixture
+def client_authed_with_session(
+    session_with_resource_id: Session,
+) -> Generator[ClientSession]:
+    client = ClientSession()
+    client.configure(session_token=session_with_resource_id.id, sandbox=True)
+    client.basic_auth = ('', '')
+    yield client

--- a/tests/resources/cassettes/test_session_create_with_resource_id.yaml
+++ b/tests/resources/cassettes/test_session_create_with_resource_id.yaml
@@ -1,0 +1,47 @@
+interactions:
+  - request:
+      body:
+        '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.metamap_verification",
+        "resource_id": "68b887f60c33abad1ea841d3"}'
+      headers:
+        Authorization:
+          - DUMMY
+        Content-Length:
+          - "122"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - cuenca-python/2.1.11.dev1
+        X-Cuenca-Api-Version:
+          - "2020-03-19"
+      method: POST
+      uri: https://sandbox.cuenca.com/sessions
+    response:
+      body:
+        string: '{"id": "SSRk8W9VPBRgixHFh0rNOejg", "created_at": "2025-09-09T19:04:37.242865", "user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "platform_id": "PTZbBlk__kQt-wfwzP5nwA9A", "expires_at": "2025-09-09T19:14:37.242877",
+         "success_url": null, "failure_url": null, "type": "session.metamap_verification", "resource_id": "68b887f60c33abad1ea841d3"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "49"
+        Content-Type:
+          - application/json
+        Date:
+          - Tue, 09 Sep 2025 19:10:56 GMT
+        x-amz-apigw-id:
+          - QphGKFeICYcEU6w=
+        x-amzn-Remapped-Connection:
+          - close
+        x-amzn-Remapped-Content-Length:
+          - "49"
+        x-amzn-Remapped-Date:
+          - Tue, 09 Sep 2025 19:10:56 GMT
+        x-amzn-Remapped-Server:
+          - nginx/1.28.0
+        x-amzn-RequestId:
+          - 0b3f6126-1702-42b2-934b-a69da53399e4
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/resources/cassettes/test_session_create_with_resource_id.yaml
+++ b/tests/resources/cassettes/test_session_create_with_resource_id.yaml
@@ -1,47 +1,47 @@
 interactions:
-  - request:
-      body:
-        '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.metamap_verification",
-        "resource_id": "68b887f60c33abad1ea841d3"}'
-      headers:
-        Authorization:
-          - DUMMY
-        Content-Length:
-          - "122"
-        Content-Type:
-          - application/json
-        User-Agent:
-          - cuenca-python/2.1.11.dev1
-        X-Cuenca-Api-Version:
-          - "2020-03-19"
-      method: POST
-      uri: https://sandbox.cuenca.com/sessions
-    response:
-      body:
-        string: '{"id": "SSRk8W9VPBRgixHFh0rNOejg", "created_at": "2025-09-09T19:04:37.242865", "user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "platform_id": "PTZbBlk__kQt-wfwzP5nwA9A", "expires_at": "2025-09-09T19:14:37.242877",
-         "success_url": null, "failure_url": null, "type": "session.metamap_verification", "resource_id": "68b887f60c33abad1ea841d3"}'
-      headers:
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "49"
-        Content-Type:
-          - application/json
-        Date:
-          - Tue, 09 Sep 2025 19:10:56 GMT
-        x-amz-apigw-id:
-          - QphGKFeICYcEU6w=
-        x-amzn-Remapped-Connection:
-          - close
-        x-amzn-Remapped-Content-Length:
-          - "49"
-        x-amzn-Remapped-Date:
-          - Tue, 09 Sep 2025 19:10:56 GMT
-        x-amzn-Remapped-Server:
-          - nginx/1.28.0
-        x-amzn-RequestId:
-          - 0b3f6126-1702-42b2-934b-a69da53399e4
-      status:
-        code: 200
-        message: OK
+- request:
+    body: '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.onboarding_verification",
+      "resource_id": "68b887f60c33abad1ea841d3"}'
+    headers:
+      Authorization:
+      - DUMMY
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - cuenca-python/2.1.11
+      X-Cuenca-Api-Version:
+      - '2020-03-19'
+    method: POST
+    uri: https://sandbox.cuenca.com/sessions
+  response:
+    body:
+      string: '{"id":"SS-x6PU8GxSpKYL9btp4Btog","created_at":"2025-09-10T20:33:32.483427","user_id":"USPR4JxMuwSG60u2h4gBpB6Q","platform_id":"PTZbBlk__kQt-wfwzP5nwA9A","expires_at":"2025-09-10T20:43:32.483438","success_url":null,"failure_url":null,"type":"session.onboarding_verification","resource_id":"68b887f60c33abad1ea841d3"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 Sep 2025 20:33:32 GMT
+      X-Request-Time:
+      - 'value: 0.167'
+      x-amz-apigw-id:
+      - QtAIfG7eCYcEsfQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '315'
+      x-amzn-Remapped-Date:
+      - Wed, 10 Sep 2025 20:33:32 GMT
+      x-amzn-Remapped-Server:
+      - nginx/1.28.0
+      x-amzn-RequestId:
+      - deb095dd-c1c6-4837-b5ac-54a0c41d9fb2
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/tests/resources/cassettes/test_session_with_resource_id_authorized.yaml
+++ b/tests/resources/cassettes/test_session_with_resource_id_authorized.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.onboarding_verification",
+      "resource_id": "68b887f60c33abad1ea841d3"}'
+    headers:
+      Authorization:
+      - DUMMY
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - cuenca-python/2.1.11
+      X-Cuenca-Api-Version:
+      - '2020-03-19'
+    method: POST
+    uri: https://sandbox.cuenca.com/sessions
+  response:
+    body:
+      string: '{"id":"SSOXga_D_VQXCPsWQT7Z0ddQ","created_at":"2025-09-10T20:33:32.875517","user_id":"USPR4JxMuwSG60u2h4gBpB6Q","platform_id":"PTZbBlk__kQt-wfwzP5nwA9A","expires_at":"2025-09-10T20:43:32.875529","success_url":null,"failure_url":null,"type":"session.onboarding_verification","resource_id":"68b887f60c33abad1ea841d3"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 Sep 2025 20:33:32 GMT
+      X-Request-Time:
+      - 'value: 0.151'
+      x-amz-apigw-id:
+      - QtAIjGCGiYcEuZw=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '315'
+      x-amzn-Remapped-Date:
+      - Wed, 10 Sep 2025 20:33:32 GMT
+      x-amzn-Remapped-Server:
+      - nginx/1.28.0
+      x-amzn-RequestId:
+      - 0d6c920d-4608-4d1c-9858-fe81fccba4b1
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - cuenca-python/2.1.11
+      X-Cuenca-Api-Version:
+      - '2020-03-19'
+      X-Cuenca-SessionId:
+      - SSOXga_D_VQXCPsWQT7Z0ddQ
+    method: GET
+    uri: https://sandbox.cuenca.com/onboarding_verifications/68b887f60c33abad1ea841d3
+  response:
+    body:
+      string: '{"gov_id_document_number":"267202610","gov_id_front":"https://media-cdn.prod.metamap.com/documents/production/9b1bccd3-1cc2-4f94-b9bc-e416f23a685c.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9kb2N1bWVudHMvcHJvZHVjdGlvbi85YjFiY2NkMy0xY2MyLTRmOTQtYjliYy1lNDE2ZjIzYTY4NWMuanBlZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc1Nzc5NTYxM319fV19&Signature=kqeDz-ik5UJTUAC3JRN4y15BMyT-ruaExqM9vCuJQ1gVr8BYjFfwZENW4qDBU0-6c4J0zxkr853-IKeEwqus~Xxn7ui0jv5MGxt4HEZOGnv-CkKx2EENt-3-GelJ9EmiSUaUkIouHr-V1MNm8-Cuea1m1TMFjnOAXpoiEbudT0-RnILGKJui90DGWSEzQsLjwz0Y7wCS2KNaIOb~ors8V~WiwULVYSJh6L0IPPKUlbAch-HocVU3uQOlBTb3e-xSKsxcLVTLHTmnXefcZvPIHIiPWtOMwBQP7~AqesIszrHQVPAaS9VLkN~2md4zVwDb6VmBHCTqtg7sxJJMjGKiRQ__&Key-Pair-Id=K3UFJ5LH7J6562","proof_of_address":"https://media-cdn.prod.metamap.com/documents/production/52ac2e59-8416-49b0-bd56-9fe1f245a8d8.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9kb2N1bWVudHMvcHJvZHVjdGlvbi81MmFjMmU1OS04NDE2LTQ5YjAtYmQ1Ni05ZmUxZjI0NWE4ZDguanBlZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc1Nzc5NTYxM319fV19&Signature=pET21fJJDoDHjd3agnQ1Aa-Ux9zuxGP9mAbrR7K4DLSeRq9tKzplchaWl3VZRBk2jeSSkcSLO0KhCmgFqGDj92SsPmIbJrB6Ay5XIjh6jQjrnGUIR3w8NFgSaxFeogoLBL5mzamyXf5KzRQ32I7xnWnIlLhhEzPGE3x74lZwIvZ04Gc1Vh5pLeBT-xFxlAtdlEW7HW3O8Y~GFo7TupQiH52YSx1c8us2URUCdXJxiRHId0-BHSTa~qk8uJghRNH~Q~4TQVlMS6LUDztvC0xaubmU7i0ArO8o3TMG~JYQcmil0kFq5XHcEwX734XyijRLRFkhWUrVLzojiSCXZwPPfA__&Key-Pair-Id=K3UFJ5LH7J6562","liveness_selfie":"https://media-cdn.prod.metamap.com/selfies/production/018fbc9f-085e-4a72-a2a4-8fe2e3d40473.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9zZWxmaWVzL3Byb2R1Y3Rpb24vMDE4ZmJjOWYtMDg1ZS00YTcyLWEyYTQtOGZlMmUzZDQwNDczLmpwZWciLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTc3OTU2MTN9fX1dfQ__&Signature=nkckXL3~GOgWMPVc9RZCTTFIoSRcaCynFSSJGwYp5FIrepxH5us8Gx-lSzyYLmse2aQZqHOudiX2MDdIJXQCXYbxuNbVPY0EtQ3AhAzDU-a4k6lh4qH0GAkuUINRjfSmpAcj6JtDqsx4icLImZlZ0CTsP8cEguJlUUW994zKqHyT0UyQRy7wB39zVKIx9arqzULKQe-RRimu1mMmRIkfo5k0ARrDQYbWNiGpxZTNaYmXayPkH2T1sSa~sIkLxjpJbWCNGZ0kMqMPuSFdWYg4RjIrHb2UHDubegi7rj5SmefeqSUCVgb7YVD1YWutXfogRIJraDm~Ph9qpLQfEvV4~Q__&Key-Pair-Id=K3UFJ5LH7J6562"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2359'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 Sep 2025 20:33:33 GMT
+      X-Request-Time:
+      - 'value: 0.388'
+      x-amz-apigw-id:
+      - QtAImGe5iYcEi4g=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '2359'
+      x-amzn-Remapped-Date:
+      - Wed, 10 Sep 2025 20:33:33 GMT
+      x-amzn-Remapped-Server:
+      - nginx/1.28.0
+      x-amzn-RequestId:
+      - 848ed62c-6ec3-4150-a3fb-5a082cb313b4
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/resources/cassettes/test_session_with_resource_id_authorized.yaml
+++ b/tests/resources/cassettes/test_session_with_resource_id_authorized.yaml
@@ -1,87 +1,88 @@
 interactions:
-- request:
-    body: '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.onboarding_verification",
-      "resource_id": "68b887f60c33abad1ea841d3"}'
-    headers:
-      Authorization:
-      - DUMMY
-      Content-Length:
-      - '125'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - cuenca-python/2.1.11
-      X-Cuenca-Api-Version:
-      - '2020-03-19'
-    method: POST
-    uri: https://sandbox.cuenca.com/sessions
-  response:
-    body:
-      string: '{"id":"SSOXga_D_VQXCPsWQT7Z0ddQ","created_at":"2025-09-10T20:33:32.875517","user_id":"USPR4JxMuwSG60u2h4gBpB6Q","platform_id":"PTZbBlk__kQt-wfwzP5nwA9A","expires_at":"2025-09-10T20:43:32.875529","success_url":null,"failure_url":null,"type":"session.onboarding_verification","resource_id":"68b887f60c33abad1ea841d3"}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '315'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 10 Sep 2025 20:33:32 GMT
-      X-Request-Time:
-      - 'value: 0.151'
-      x-amz-apigw-id:
-      - QtAIjGCGiYcEuZw=
-      x-amzn-Remapped-Connection:
-      - keep-alive
-      x-amzn-Remapped-Content-Length:
-      - '315'
-      x-amzn-Remapped-Date:
-      - Wed, 10 Sep 2025 20:33:32 GMT
-      x-amzn-Remapped-Server:
-      - nginx/1.28.0
-      x-amzn-RequestId:
-      - 0d6c920d-4608-4d1c-9858-fe81fccba4b1
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      User-Agent:
-      - cuenca-python/2.1.11
-      X-Cuenca-Api-Version:
-      - '2020-03-19'
-      X-Cuenca-SessionId:
-      - SSOXga_D_VQXCPsWQT7Z0ddQ
-    method: GET
-    uri: https://sandbox.cuenca.com/onboarding_verifications/68b887f60c33abad1ea841d3
-  response:
-    body:
-      string: '{"gov_id_document_number":"267202610","gov_id_front":"https://media-cdn.prod.metamap.com/documents/production/9b1bccd3-1cc2-4f94-b9bc-e416f23a685c.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9kb2N1bWVudHMvcHJvZHVjdGlvbi85YjFiY2NkMy0xY2MyLTRmOTQtYjliYy1lNDE2ZjIzYTY4NWMuanBlZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc1Nzc5NTYxM319fV19&Signature=kqeDz-ik5UJTUAC3JRN4y15BMyT-ruaExqM9vCuJQ1gVr8BYjFfwZENW4qDBU0-6c4J0zxkr853-IKeEwqus~Xxn7ui0jv5MGxt4HEZOGnv-CkKx2EENt-3-GelJ9EmiSUaUkIouHr-V1MNm8-Cuea1m1TMFjnOAXpoiEbudT0-RnILGKJui90DGWSEzQsLjwz0Y7wCS2KNaIOb~ors8V~WiwULVYSJh6L0IPPKUlbAch-HocVU3uQOlBTb3e-xSKsxcLVTLHTmnXefcZvPIHIiPWtOMwBQP7~AqesIszrHQVPAaS9VLkN~2md4zVwDb6VmBHCTqtg7sxJJMjGKiRQ__&Key-Pair-Id=K3UFJ5LH7J6562","proof_of_address":"https://media-cdn.prod.metamap.com/documents/production/52ac2e59-8416-49b0-bd56-9fe1f245a8d8.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9kb2N1bWVudHMvcHJvZHVjdGlvbi81MmFjMmU1OS04NDE2LTQ5YjAtYmQ1Ni05ZmUxZjI0NWE4ZDguanBlZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc1Nzc5NTYxM319fV19&Signature=pET21fJJDoDHjd3agnQ1Aa-Ux9zuxGP9mAbrR7K4DLSeRq9tKzplchaWl3VZRBk2jeSSkcSLO0KhCmgFqGDj92SsPmIbJrB6Ay5XIjh6jQjrnGUIR3w8NFgSaxFeogoLBL5mzamyXf5KzRQ32I7xnWnIlLhhEzPGE3x74lZwIvZ04Gc1Vh5pLeBT-xFxlAtdlEW7HW3O8Y~GFo7TupQiH52YSx1c8us2URUCdXJxiRHId0-BHSTa~qk8uJghRNH~Q~4TQVlMS6LUDztvC0xaubmU7i0ArO8o3TMG~JYQcmil0kFq5XHcEwX734XyijRLRFkhWUrVLzojiSCXZwPPfA__&Key-Pair-Id=K3UFJ5LH7J6562","liveness_selfie":"https://media-cdn.prod.metamap.com/selfies/production/018fbc9f-085e-4a72-a2a4-8fe2e3d40473.jpeg?Expires=1757795613&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9tZWRpYS1jZG4ucHJvZC5tZXRhbWFwLmNvbS9zZWxmaWVzL3Byb2R1Y3Rpb24vMDE4ZmJjOWYtMDg1ZS00YTcyLWEyYTQtOGZlMmUzZDQwNDczLmpwZWciLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTc3OTU2MTN9fX1dfQ__&Signature=nkckXL3~GOgWMPVc9RZCTTFIoSRcaCynFSSJGwYp5FIrepxH5us8Gx-lSzyYLmse2aQZqHOudiX2MDdIJXQCXYbxuNbVPY0EtQ3AhAzDU-a4k6lh4qH0GAkuUINRjfSmpAcj6JtDqsx4icLImZlZ0CTsP8cEguJlUUW994zKqHyT0UyQRy7wB39zVKIx9arqzULKQe-RRimu1mMmRIkfo5k0ARrDQYbWNiGpxZTNaYmXayPkH2T1sSa~sIkLxjpJbWCNGZ0kMqMPuSFdWYg4RjIrHb2UHDubegi7rj5SmefeqSUCVgb7YVD1YWutXfogRIJraDm~Ph9qpLQfEvV4~Q__&Key-Pair-Id=K3UFJ5LH7J6562"}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2359'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 10 Sep 2025 20:33:33 GMT
-      X-Request-Time:
-      - 'value: 0.388'
-      x-amz-apigw-id:
-      - QtAImGe5iYcEi4g=
-      x-amzn-Remapped-Connection:
-      - keep-alive
-      x-amzn-Remapped-Content-Length:
-      - '2359'
-      x-amzn-Remapped-Date:
-      - Wed, 10 Sep 2025 20:33:33 GMT
-      x-amzn-Remapped-Server:
-      - nginx/1.28.0
-      x-amzn-RequestId:
-      - 848ed62c-6ec3-4150-a3fb-5a082cb313b4
-    status:
-      code: 200
-      message: OK
+  - request:
+      body:
+        '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.onboarding_verification",
+        "resource_id": "68b887f60c33abad1ea841d3"}'
+      headers:
+        Authorization:
+          - DUMMY
+        Content-Length:
+          - "125"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - cuenca-python/2.1.11
+        X-Cuenca-Api-Version:
+          - "2020-03-19"
+      method: POST
+      uri: https://sandbox.cuenca.com/sessions
+    response:
+      body:
+        string: '{"id":"SSOXga_D_VQXCPsWQT7Z0ddQ","created_at":"2025-09-10T20:33:32.875517","user_id":"USPR4JxMuwSG60u2h4gBpB6Q","platform_id":"PTZbBlk__kQt-wfwzP5nwA9A","expires_at":"2025-09-10T20:43:32.875529","success_url":null,"failure_url":null,"type":"session.onboarding_verification","resource_id":"68b887f60c33abad1ea841d3"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "315"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 10 Sep 2025 20:33:32 GMT
+        X-Request-Time:
+          - "value: 0.151"
+        x-amz-apigw-id:
+          - QtAIjGCGiYcEuZw=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "315"
+        x-amzn-Remapped-Date:
+          - Wed, 10 Sep 2025 20:33:32 GMT
+        x-amzn-Remapped-Server:
+          - nginx/1.28.0
+        x-amzn-RequestId:
+          - 0d6c920d-4608-4d1c-9858-fe81fccba4b1
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        User-Agent:
+          - cuenca-python/2.1.11
+        X-Cuenca-Api-Version:
+          - "2020-03-19"
+        X-Cuenca-SessionId:
+          - SSOXga_D_VQXCPsWQT7Z0ddQ
+      method: GET
+      uri: https://sandbox.cuenca.com/onboarding_verifications/68b887f60c33abad1ea841d3
+    response:
+      body:
+        string: '{"gov_id_document_number":"267202610","gov_id_front":"https://media-cdn.prod.metamap.com","proof_of_address":"https://media-cdn.prod.metamap.com","liveness_selfie":"https://media-cdn.prod.metamap.com"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "2359"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 10 Sep 2025 20:33:33 GMT
+        X-Request-Time:
+          - "value: 0.388"
+        x-amz-apigw-id:
+          - QtAImGe5iYcEi4g=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "2359"
+        x-amzn-Remapped-Date:
+          - Wed, 10 Sep 2025 20:33:33 GMT
+        x-amzn-Remapped-Server:
+          - nginx/1.28.0
+        x-amzn-RequestId:
+          - 848ed62c-6ec3-4150-a3fb-5a082cb313b4
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/resources/cassettes/test_session_with_resource_id_unauthorized.yaml
+++ b/tests/resources/cassettes/test_session_with_resource_id_unauthorized.yaml
@@ -1,0 +1,86 @@
+interactions:
+  - request:
+      body:
+        '{"user_id": "USPR4JxMuwSG60u2h4gBpB6Q", "type": "session.onboarding_verification",
+        "resource_id": "68b887f60c33abad1ea841d3"}'
+      headers:
+        Authorization:
+          - DUMMY
+        Content-Length:
+          - "125"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - cuenca-python/2.1.11
+        X-Cuenca-Api-Version:
+          - "2020-03-19"
+      method: POST
+      uri: https://sandbox.cuenca.com/sessions
+    response:
+      body:
+        string: '{"id":"SSsxQina5sTNii7gv--OXg1g","created_at":"2025-09-10T20:34:31.525777","user_id":"USPR4JxMuwSG60u2h4gBpB6Q","platform_id":"PTZbBlk__kQt-wfwzP5nwA9A","expires_at":"2025-09-10T20:44:31.525789","success_url":null,"failure_url":null,"type":"session.onboarding_verification","resource_id":"68b887f60c33abad1ea841d3"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "315"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 10 Sep 2025 20:34:31 GMT
+        X-Request-Time:
+          - "value: 0.129"
+        x-amz-apigw-id:
+          - QtARtGC6iYcEJYA=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "315"
+        x-amzn-Remapped-Date:
+          - Wed, 10 Sep 2025 20:34:31 GMT
+        x-amzn-Remapped-Server:
+          - nginx/1.28.0
+        x-amzn-RequestId:
+          - 965c6cc2-31d3-4024-9c21-09ae6d4da534
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        User-Agent:
+          - cuenca-python/2.1.11
+        X-Cuenca-Api-Version:
+          - "2020-03-19"
+        X-Cuenca-SessionId:
+          - SSsxQina5sTNii7gv--OXg1g
+      method: GET
+      uri: https://sandbox.cuenca.com/onboarding_verifications/68b887f60c33abad1ea841d4
+    response:
+      body:
+        string: '{"error":"User has not enough permissions"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "43"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 10 Sep 2025 20:34:31 GMT
+        x-amz-apigw-id:
+          - QtARxHZtCYcEoCg=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "43"
+        x-amzn-Remapped-Date:
+          - Wed, 10 Sep 2025 20:34:31 GMT
+        x-amzn-Remapped-Server:
+          - nginx/1.28.0
+        x-amzn-RequestId:
+          - c9539c27-70d2-4821-8afc-4bd7146253ef
+      status:
+        code: 401
+        message: Unauthorized
+version: 1

--- a/tests/resources/test_sessions.py
+++ b/tests/resources/test_sessions.py
@@ -37,4 +37,18 @@ def test_session_create(curp_validation_request: dict, user_request: dict):
     ephimeral_cuenca_session.configure(session_token=user_session.id)
 
     user = User.update(user.id, profession=Profession.comercio)
-    assert user.profession == str(Profession.comercio)
+    assert user.profession == Profession.comercio
+
+
+@pytest.mark.vcr
+def test_session_create_with_resource_id(
+    curp_validation_request: dict, user_request: dict
+) -> None:
+    session = Session.create(
+        'USPR4JxMuwSG60u2h4gBpB6Q',
+        SessionType.metamap_verification,
+        resource_id='68b887f60c33abad1ea841d3',
+    )
+
+    assert session.user_id == 'USPR4JxMuwSG60u2h4gBpB6Q'
+    assert session.resource_id == '68b887f60c33abad1ea841d3'

--- a/tests/resources/test_sessions.py
+++ b/tests/resources/test_sessions.py
@@ -37,4 +37,4 @@ def test_session_create(curp_validation_request: dict, user_request: dict):
     ephimeral_cuenca_session.configure(session_token=user_session.id)
 
     user = User.update(user.id, profession=Profession.comercio)
-    assert user.profession == Profession.comercio
+    assert user.profession == str(Profession.comercio)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Sessions now accept an optional resource_id; it appears in session responses and schema examples.

- Chores
  - Bumped package version to 2.1.11.
  - Updated dependency: cuenca-validations to 2.1.17.dev4.

- Tests
  - Added tests and recorded fixtures for session creation with resource_id, authorized access, and unauthorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->